### PR TITLE
CPP-538 Update to support Webpack 5 instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
     "check-engine": "^1.10.1",
     "jasmine": "^3.5.0",
     "prettier": "^2.0.0",
-    "webpack": "^4.41.0"
+    "webpack": "^5.64.4"
   },
   "peerDependencies": {
-    "webpack": "^4.38.0"
+    "webpack": "5.x"
   },
   "repository": {
     "type": "git",

--- a/src/markAsUsed.js
+++ b/src/markAsUsed.js
@@ -1,8 +1,8 @@
-module.exports = (m, mg, rt) => {
-  const ei = mg.getExportsInfo(m)
-  ei.setUsedInUnknownWay(rt)
-  if (m.factoryMeta === undefined) {
-    m.factoryMeta = {}
+module.exports = (module, moduleGraph, runtime) => {
+  const exportsInfo = moduleGraph.getExportsInfo(module)
+  exportsInfo.setUsedInUnknownWay(runtime)
+  if (module.factoryMeta === undefined) {
+    module.factoryMeta = {}
   }
-  m.factoryMeta.sideEffectFree = false
+  module.factoryMeta.sideEffectFree = false
 }

--- a/src/markAsUsed.js
+++ b/src/markAsUsed.js
@@ -1,5 +1,8 @@
-module.exports = (m) => {
-  m.used = true
-  m.usedExports = true
-  m.buildMeta.providedExports = true
+module.exports = (m, mg, rt) => {
+  const ei = mg.getExportsInfo(m)
+  ei.setUsedInUnknownWay(rt)
+  if (m.factoryMeta === undefined) {
+    m.factoryMeta = {}
+  }
+  m.factoryMeta.sideEffectFree = false
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,4 +1,5 @@
 const ConcatenatedModule = require('webpack/lib/optimize/ConcatenatedModule')
+const { mergeRuntimeOwned, getEntryRuntime } = require('webpack/lib/util/runtime')
 const isTargetChunk = require('./isTargetChunk')
 const markAsUsed = require('./markAsUsed')
 
@@ -15,16 +16,23 @@ class DisableTreeShakingForChunkPlugin {
 
   apply(compiler) {
     compiler.hooks.compilation.tap(PluginName, (compilation) => {
+      const { moduleGraph } = compilation
       compilation.hooks.afterOptimizeChunkModules.tap(PluginName, (chunks) => {
-        const targetChunks = chunks.filter((chunk) => isTargetChunk(chunk.name, this.test))
+        const targetChunks = Array.from(chunks).filter((chunk) =>
+          isTargetChunk(chunk.name, this.test)
+        )
+        let runtime = undefined
+        for (const [name, { options }] of compilation.entries) {
+          runtime = mergeRuntimeOwned(runtime, getEntryRuntime(compilation, name, options))
+        }
 
         targetChunks.forEach((targetChunk) => {
-          targetChunk.modulesIterable.forEach((m) => {
+          compilation.chunkGraph.getChunkModulesIterable(targetChunk).forEach((m) => {
             if (m.type.startsWith('javascript/')) {
-              markAsUsed(m)
+              markAsUsed(m, moduleGraph, runtime)
 
               if (m instanceof ConcatenatedModule) {
-                markAsUsed(m.rootModule)
+                markAsUsed(m.rootModule, moduleGraph, runtime)
               }
             }
           })

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -27,12 +27,12 @@ class DisableTreeShakingForChunkPlugin {
         }
 
         targetChunks.forEach((targetChunk) => {
-          compilation.chunkGraph.getChunkModulesIterable(targetChunk).forEach((m) => {
-            if (m.type.startsWith('javascript/')) {
-              markAsUsed(m, moduleGraph, runtime)
+          compilation.chunkGraph.getChunkModulesIterable(targetChunk).forEach((module) => {
+            if (module.type.startsWith('javascript/')) {
+              markAsUsed(module, moduleGraph, runtime)
 
-              if (m instanceof ConcatenatedModule) {
-                markAsUsed(m.rootModule, moduleGraph, runtime)
+              if (module instanceof ConcatenatedModule) {
+                markAsUsed(module.rootModule, moduleGraph, runtime)
               }
             }
           })


### PR DESCRIPTION
The Webpack plugin ecosystem is undocumented so I've based the work on the internal work linked in the PR, #4, i.e.:

- https://github.com/webpack/webpack/blob/main/lib/FlagAllModulesAsUsedPlugin.js
- https://github.com/webpack/webpack/issues/10025

Support for Webpack 4 will be dropped so this will be released in a new major version.

Closes #4 