### PR TITLE
update config for nightly scheduled-pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,11 @@ workflows:
   version: 2
 
   build-test:
+    when:
+      not:
+        equal:
+          - scheduled_pipeline
+          - << pipeline.trigger_source >>
     jobs:
       - build:
           filters:
@@ -143,6 +148,11 @@ workflows:
             - build
 
   build-test-publish:
+    when:
+      not:
+        equal:
+          - scheduled_pipeline
+          - << pipeline.trigger_source >>
     jobs:
       - build:
           filters:
@@ -160,6 +170,11 @@ workflows:
             - test
 
   renovate-nori-build-test:
+    when:
+      not:
+        equal:
+          - scheduled_pipeline
+          - << pipeline.trigger_source >>
     jobs:
       - waiting-for-approval:
           type: approval
@@ -173,11 +188,14 @@ workflows:
             - build
 
   nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            <<: *filters_only_main
+    when:
+      and:
+        - equal:
+            - scheduled_pipeline
+            - << pipeline.trigger_source >>
+        - equal:
+            - nightly
+            - << pipeline.schedule.name >>
     jobs:
       - build:
           context: next-nightly-build


### PR DESCRIPTION
Applies workflows filtering to your circleci/config.yml, so that the nightly workflow runs with the scheduled trigger, and other workflows won't run with the scheduled trigger.