### PR TITLE
fix: don't set sideEffectFree to false

### DIFF
--- a/src/markAsUsed.js
+++ b/src/markAsUsed.js
@@ -1,8 +1,4 @@
 module.exports = (module, moduleGraph, runtime) => {
   const exportsInfo = moduleGraph.getExportsInfo(module)
   exportsInfo.setUsedInUnknownWay(runtime)
-  if (module.factoryMeta === undefined) {
-    module.factoryMeta = {}
-  }
-  module.factoryMeta.sideEffectFree = false
 }


### PR DESCRIPTION
jesus fuck this was an ordeal

this property is seemingly already correctly calculated for most cases, so what happens in practice when unconditionally setting it is that modules that have been hoisted and elided due to module concatenation (e.g. modules that only contain `export * from`) are prohibited from having their imports optimised out; however, because the modules themselves aren't being output into a chunk, they have a `null` module id.

removing setting this property doesn't stop this plugin from disabling tree shaking at all, but does correctly allow these modules to have their imports be removed.

example diff with `sideEffectFree` removed: https://github.com/Financial-Times/next-stream-page/commit/afc76316cceb4d4fb2aec0bda3dc0db83d9b84dd

example diff with `usedInUnknownWay` _also_ removed, demonstrating that this plugin is in fact correctly preventing tree shaking without `sideEffectFree`: https://github.com/Financial-Times/next-stream-page/commit/0e181d8347feecc22d8b2d153c6caa5dbcea5a73